### PR TITLE
Update composer.json to require league/commonmark 0.15.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "league/commonmark": "^0.12.0"
+        "league/commonmark": "^0.15.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0"


### PR DESCRIPTION
Hi Marijn,

I would like to use your commonmark-strikethrough-extension in one of my projects, however I'm using version 0.15 of commonmark. Would you consider adding a new tag for this version so we can use your extension ?

Thank you